### PR TITLE
Fix package description

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
     "id": "discourse",
     "packaging_format": 1,
     "description": {
-        "en": "photo gallery",
-        "fr": "Galerie photo"
+        "en": "Discussion platform",
+        "fr": "Plateforme de discussion"
     },
     "version": "2.0.2~ynh1",
     "url": "http://Discourse.org",


### PR DESCRIPTION
Small oversight fixed, description was about a photo gallery.

I used the "discussion platform" description from [the about page of Discourse](https://www.discourse.org/about).