### PR TITLE
Fix path_url - path

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -54,8 +54,6 @@ check_memory_requirements
 # STORE SETTINGS FROM MANIFEST
 #=================================================
 
-ynh_app_setting_set $app domain "$domain"
-ynh_app_setting_set $app path_url "$path_url"
 ynh_app_setting_set $app admin "$admin"
 ynh_app_setting_set $app is_public "$is_public"
 ynh_app_setting_set $app final_path $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -28,7 +28,7 @@ ynh_abort_if_errors
 app=$YNH_APP_INSTANCE_NAME
 
 domain=$(ynh_app_setting_get $app domain)
-path_url=$(ynh_app_setting_get $app path_url)
+path_url=$(ynh_app_setting_get $app path)
 final_path=$(ynh_app_setting_get $app final_path)
 is_public=$(ynh_app_setting_get $app is_public)
 admin=$(ynh_app_setting_get $app admin)


### PR DESCRIPTION
# Problem

While we call the change_url script the path_url is not updated by the core. Yunohost is originally made to manage the `path` key and not `path_url`.

# Solution 

Use the `path` key and not `path_url`.

Note that the `path` and the `domain` key is managed by Yunohost (when we call `ynh_webpath_register`) we don't need to set the value for these key in the install script.

Tested with CI [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/discourse_ynh%20(josue)/3/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/discourse_ynh%20(josue)/3) 