### PR TITLE
libcurl4-openssl-dev -> libcurl4-dev

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -4,7 +4,7 @@
 # COMMON VARIABLES
 #=================================================
 
-pkg_dependencies="g++ libjemalloc1|libjemalloc2 libjemalloc-dev zlib1g-dev libreadline-dev libpq-dev libssl-dev libyaml-dev libcurl4-openssl-dev libapr1-dev libxslt1-dev libxml2-dev vim imagemagick postgresql postgresql-server-dev-all postgresql-contrib optipng jhead jpegoptim gifsicle brotli"
+pkg_dependencies="g++ libjemalloc1|libjemalloc2 libjemalloc-dev zlib1g-dev libreadline-dev libpq-dev libssl-dev libyaml-dev libcurl4-dev libapr1-dev libxslt1-dev libxml2-dev vim imagemagick postgresql postgresql-server-dev-all postgresql-contrib optipng jhead jpegoptim gifsicle brotli"
 
 RUBY_VERSION="2.6.5"
 


### PR DESCRIPTION
c.f. https://github.com/YunoHost-Apps/discourse_ynh/issues/45

We're trying to fix some weird cross-apps conflicts because of stupid dependency conflicts ... in particular various app require different versions of libcurl4-*-dev conflicting with each other, but it should be fine to just request libcurl4-dev