### PR TITLE
Upgrade to upstream version 2.5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Finally, if installing on a low-end ARM device (e.g. Raspberry Pi):
 
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
-**Shipped version:** 2.5.4
+**Shipped version:** 2.5.5
 
 ## Screenshots
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/discourse/discourse/archive/v2.5.4.tar.gz
-SOURCE_SUM=aa2b2cd9efdde3d50c930593e2ab13a634759f77d4d6dcd613a714ccbc30ec86
+SOURCE_URL=https://github.com/discourse/discourse/archive/v2.5.5.tar.gz
+SOURCE_SUM=22086033c797eaaa984c50f2256ceb7b7c45e5951191c5399d1a4e10fb201319
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Discussion platform",
         "fr": "Plateforme de discussion"
     },
-    "version": "2.5.4~ynh1",
+    "version": "2.5.5~ynh1",
     "url": "http://Discourse.org",
     "license": "GPL-2.0",
     "maintainer": {


### PR DESCRIPTION
## Problem
- *Package not up-to-date with upstream*

## Solution
- *Upgrade to latest version 2.5.5*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/discourse_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/discourse_ynh%20PR-NUM-%20(USERNAME)/)  
