### PR TITLE
Upgrade to upstream version 2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Finally, if installing on a low-end ARM device (e.g. Raspberry Pi):
 
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
-**Shipped version:** 2.6.0
+**Shipped version:** 2.6.1
 
 ## Screenshots
 

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/discourse/discourse/archive/v2.6.0.tar.gz
-SOURCE_SUM=29b35fe3f8c7e8957dc1fdc54b3cf6668b51d9a886ceabe0e6b83ba4b64b2f8e
+SOURCE_URL=https://github.com/discourse/discourse/archive/v2.6.1.tar.gz
+SOURCE_SUM=f62f50c7491e114be42ece5d5d8e4072fe98bdd7955b962dbe6b241b38f453c7
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Discussion platform",
         "fr": "Plateforme de discussion"
     },
-    "version": "2.6.0~ynh1",
+    "version": "2.6.1~ynh1",
     "url": "http://Discourse.org",
     "license": "GPL-2.0",
     "maintainer": {


### PR DESCRIPTION
## Problem
- *The application is not up-to-date with the upstream*

## Solution
- *Upgrade to upstream version 2.6.1*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/discourse_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/discourse_ynh%20PR-NUM-%20(USERNAME)/)  
