### PR TITLE
Upgrade discourse-ldap-auth plugin ( #126)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Discourse is modern forum software for your community. Use it as a mailing list, discussion forum, long-form chat room, and more!
 
-**Shipped version:** 2.8.7~ynh1
+**Shipped version:** 2.8.7~ynh2
+
 
 **Demo:** https://try.discourse.org
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,8 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Discourse est un logiciel de forum moderne pour votre communauté. Utilisez-le comme liste de diffusion, forum de discussion, salle de discussion longue durée, et plus encore !
 
-**Version incluse :** 2.8.7~ynh1
+**Version incluse :** 2.8.7~ynh2
+
 
 **Démo :** https://try.discourse.org
 

--- a/conf/ldap-auth.src
+++ b/conf/ldap-auth.src
@@ -1,3 +1,3 @@
-SOURCE_URL=https://github.com/jonmbake/discourse-ldap-auth/archive/v0.4.1.tar.gz
-SOURCE_SUM=08afddecc236cb04f515fe510553c1530bfbec32470682bee89cde1760f4c81f
+SOURCE_URL=https://github.com/jonmbake/discourse-ldap-auth/archive/v0.6.0.tar.gz
+SOURCE_SUM=1f64f90f648f53b40608912221adb60d86c8c13856aaba68c645cd88279445d4
 SOURCE_FORMAT=tar.gz

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Discussion platform",
         "fr": "Plateforme de discussion"
     },
-    "version": "2.8.7~ynh1",
+    "version": "2.8.7~ynh2",
     "url": "http://Discourse.org",
     "upstream": {
         "license": "GPL-2.0",


### PR DESCRIPTION
- *Upgrade discourse-ldap-auth plugin to ensure compatibility with discourse 2.8.x*

## Solution

- *And how do you fix that problem*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
