### PR TITLE
Replace the ynh_die with ynh_print_warn

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -32,10 +32,10 @@ is_swap_present() {
   [ $(awk '/^SwapTotal:/{print $2}' /proc/meminfo)  -gt 0 ]
 }
 
-# Returns true if swappiness higher than 50
+# Returns true if swappiness higher than 10
 # usage: is_swappiness_sufficient
 is_swappiness_sufficient() {
-  [ $(cat /proc/sys/vm/swappiness)  -gt 50 ]
+  [ $(cat /proc/sys/vm/swappiness)  -gt 10 ]
 }
 
 # Returns true if specified free memory is available (RAM + swap)
@@ -53,7 +53,7 @@ check_memory_requirements() {
   if ! is_swap_present ; then
     ynh_die --message="You must have a swap partition in order to install and use this application"
   elif ! is_swappiness_sufficient ; then
-    ynh_die --message="Your swappiness must be higher than 50; please see https://en.wikipedia.org/wiki/Swappiness"
+    ynh_die --message="Your swappiness must be higher than 10; please see https://en.wikipedia.org/wiki/Swappiness"
   elif ! is_memory_available 1000000 ; then
     ynh_die --message="You must have a minimum of 1Gb available memory (RAM+swap) for the installation"
   fi

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -51,11 +51,11 @@ is_memory_available() {
 # terminates installation if requirements not met
 check_memory_requirements() {
   if ! is_swap_present ; then
-    ynh_die --message="You must have a swap partition in order to install and use this application"
+    ynh_print_warn --message="You must have a swap partition in order to install and use this application"
   elif ! is_swappiness_sufficient ; then
-    ynh_die --message="Your swappiness must be higher than 10; please see https://en.wikipedia.org/wiki/Swappiness"
+    ynh_print_warn --message="Your swappiness must be higher than 10; please see https://en.wikipedia.org/wiki/Swappiness"
   elif ! is_memory_available 1000000 ; then
-    ynh_die --message="You must have a minimum of 1Gb available memory (RAM+swap) for the installation"
+    ynh_print_warn --message="You must have a minimum of 1Gb available memory (RAM+swap) for the installation"
   fi
 }
 # Checks discourse upgrade memory requirements


### PR DESCRIPTION
Discourse recommends a swapiness of 10 not 50. For example on some servers, like mine, you cannot change the swapiness and it is usually 10. Makes more sense I think.

For example I have plenty of RAM but cannot install Discourse because it forces me to have a swapiness of 50. My VPS provider does not allow me to change that....I am sure others are in the same situation.
