### PR TITLE
Bump ruby to 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ systemctl restart discourse
 
 * Official app website: <http://Discourse.org>
 * Upstream app code repository: <https://github.com/discourse/discourse>
-* YunoHost documentation for this app: <https://yunohost.org/app_discourse>
+* YunoHost Store: <https://apps.yunohost.org/app/discourse>
 * Report a bug: <https://github.com/YunoHost-Apps/discourse_ynh/issues>
 
 ## Developer info

--- a/README_fr.md
+++ b/README_fr.md
@@ -197,7 +197,7 @@ systemctl restart discourse
 
 * Site officiel de l’app : <http://Discourse.org>
 * Dépôt de code officiel de l’app : <https://github.com/discourse/discourse>
-* Documentation YunoHost pour cette app : <https://yunohost.org/app_discourse>
+* YunoHost Store: <https://apps.yunohost.org/app/discourse>
 * Signaler un bug : <https://github.com/YunoHost-Apps/discourse_ynh/issues>
 
 ## Informations pour les développeurs

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -9,7 +9,7 @@
 pkg_dependencies="postgresql postgresql-client postgresql-contrib imagemagick libjemalloc1|libjemalloc2"
 build_pkg_dependencies="libcurl4-openssl-dev libyaml-dev libxml2-dev libpq-dev libreadline-dev brotli libunwind-dev libtcmalloc-minimal4 cmake pngcrush pngquant advancecomp jhead jpegoptim libjpeg-turbo-progs optipng"
 
-ruby_version="2.7.6"
+ruby_version="3.0.0"
 
 nodejs_version="16"
 


### PR DESCRIPTION
## Problem

- As seen in other PR, the install fail due to an incompatible version of ruby. ( error message specify version 3.0.0 as minimal )

## Solution

- Bumping the ruby version to 3.0.0. I tested on my cloud install via a custom install ( specifying private repo at install time )

## PR Status

- [X ] Code finished and ready to be reviewed/tested
- [ X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
