### PR TITLE
Upgrade to v3.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It shall NOT be edited by hand.
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
 
-**Shipped version:** 3.4.0~ynh3
+**Shipped version:** 3.4.1~ynh1
 
 **Demo:** <https://try.discourse.org>
 

--- a/README_es.md
+++ b/README_es.md
@@ -27,7 +27,7 @@ No se debe editar a mano.
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
 
-**Versión actual:** 3.4.0~ynh3
+**Versión actual:** 3.4.1~ynh1
 
 **Demo:** <https://try.discourse.org>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -27,7 +27,7 @@ EZ editatu eskuz.
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
 
-**Paketatutako bertsioa:** 3.4.0~ynh3
+**Paketatutako bertsioa:** 3.4.1~ynh1
 
 **Demoa:** <https://try.discourse.org>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -27,7 +27,7 @@ Il NE doit PAS être modifié à la main.
 Pour en savoir plus sur la philosophie et les objectifs du projet, [visitez **discourse.org**](http://www.discourse.org).
 
 
-**Version incluse :** 3.4.0~ynh3
+**Version incluse :** 3.4.1~ynh1
 
 **Démo :** <https://try.discourse.org>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -27,7 +27,7 @@ NON debe editarse manualmente.
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
 
-**Versión proporcionada:** 3.4.0~ynh3
+**Versión proporcionada:** 3.4.1~ynh1
 
 **Demo:** <https://try.discourse.org>
 

--- a/README_id.md
+++ b/README_id.md
@@ -27,7 +27,7 @@ Ini TIDAK boleh diedit dengan tangan.
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
 
-**Versi terkirim:** 3.4.0~ynh3
+**Versi terkirim:** 3.4.1~ynh1
 
 **Demo:** <https://try.discourse.org>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -27,7 +27,7 @@ Hij mag NIET handmatig aangepast worden.
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
 
-**Geleverde versie:** 3.4.0~ynh3
+**Geleverde versie:** 3.4.1~ynh1
 
 **Demo:** <https://try.discourse.org>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -27,7 +27,7 @@ Nie powinno być ono edytowane ręcznie.
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
 
-**Dostarczona wersja:** 3.4.0~ynh3
+**Dostarczona wersja:** 3.4.1~ynh1
 
 **Demo:** <https://try.discourse.org>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -27,7 +27,7 @@
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
 
-**Поставляемая версия:** 3.4.0~ynh3
+**Поставляемая версия:** 3.4.1~ynh1
 
 **Демо-версия:** <https://try.discourse.org>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -27,7 +27,7 @@
 To learn more about the philosophy and goals of the project, [visit **discourse.org**](http://www.discourse.org).
 
 
-**分发版本：** 3.4.0~ynh3
+**分发版本：** 3.4.1~ynh1
 
 **演示：** <https://try.discourse.org>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Discourse"
 description.en = "Discussion platform"
 description.fr = "Plateforme de discussion"
 
-version = "3.4.0~ynh3"
+version = "3.4.1~ynh1"
 
 maintainers = ["JimboJoe"]
 
@@ -48,8 +48,8 @@ ram.runtime = "1G"
 [resources]
     [resources.sources]
     [resources.sources.main]
-    url = "https://github.com/discourse/discourse/archive/refs/tags/v3.4.0.tar.gz"
-    sha256 = "1dcff255a3367e1ae072ce688dd05ce3410c43197423b004c26d77f5ff68722a"
+    url = "https://github.com/discourse/discourse/archive/refs/tags/v3.4.1.tar.gz"
+    sha256 = "1b60d8b7cea529d8135f75d4f712bc2dedc70e753360db1dbe038f0955d2e847"
 
     autoupdate.strategy = "latest_github_tag"
 


### PR DESCRIPTION
Upgrade sources
- `main` v3.4.1: https://github.com/discourse/discourse/releases/tag/3.4.1

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
