### PR TITLE
Upgrade to v2026.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Discussion platform
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](http://Discourse.org)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://try.discourse.org)
-[![Version: 2025.12.0~ynh3](https://img.shields.io/badge/Version-2025.12.0~ynh3-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/discourse/)
+[![Version: 2026.1.0~ynh1](https://img.shields.io/badge/Version-2026.1.0~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/discourse/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/discourse"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Discourse"
 description.en = "Discussion platform"
 description.fr = "Plateforme de discussion"
 
-version = "2025.12.0~ynh3"
+version = "2026.1.0~ynh1"
 
 maintainers = ["JimboJoe"]
 
@@ -49,8 +49,8 @@ ram.runtime = "1G"
 [resources]
     [resources.sources]
     [resources.sources.main]
-    url = "https://github.com/discourse/discourse/archive/refs/tags/v2025.12.0.tar.gz"
-    sha256 = "afbcf92d0623eaa0b93c22daab0347308eb652fe8e0b82f2564d66c30794084a"
+    url = "https://github.com/discourse/discourse/archive/refs/tags/v2026.1.0.tar.gz"
+    sha256 = "3340309ace9aa41335736b273608b2b238a4cdd518ef8ebd53bbc788deb1a729"
 
     autoupdate.strategy = "latest_github_tag"
 

--- a/scripts/install
+++ b/scripts/install
@@ -126,7 +126,7 @@ pushd "$install_dir/discourse"
 popd
 
 pushd "$install_dir/discourse"
-    ynh_hide_warnings npm install --location=global pnpm@9 --force
+    ynh_hide_warnings npm install --location=global pnpm@10 --force
     ynh_hide_warnings _exec_as_app_with_ruby_node pnpm install --frozen-lockfile
 popd
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -190,7 +190,7 @@ popd
 pushd "$install_dir/discourse"
     ynh_hide_warnings npm install --location=global terser
     ynh_hide_warnings npm install --location=global uglify-js
-    ynh_hide_warnings npm install --location=global pnpm@9
+    ynh_hide_warnings npm install --location=global pnpm@10
     ynh_hide_warnings _exec_as_app_with_ruby_node pnpm install --frozen-lockfile
 popd
 


### PR DESCRIPTION
Upgrade sources
- `main` v2026.1.0: https://github.com/discourse/discourse/releases/tag/2026.1.0