### PR TITLE
[enh] Allows to use forward email as primary email and fix missing filter

### DIFF
--- a/conf/settings.yml
+++ b/conf/settings.yml
@@ -21,6 +21,6 @@ plugins:
     default: ''
     secret: true
   ldap_filter:
-    default: ''
+    default: '(&(|(objectclass=posixAccount))(uid=%{username})(permission=cn=__APP__.main,ou=permission,dc=yunohost,dc=org))'
   ldap_email:
     default: 'email'

--- a/conf/settings.yml
+++ b/conf/settings.yml
@@ -4,7 +4,7 @@ plugins:
   ldap_user_create_mode:
     default: 'auto'
   ldap_lookup_users_by:
-    default: 'email'
+    default: 'username'
   ldap_hostname:
     default: 'localhost'
   ldap_port:

--- a/conf/settings.yml
+++ b/conf/settings.yml
@@ -22,3 +22,5 @@ plugins:
     secret: true
   ldap_filter:
     default: ''
+  ldap_email:
+    default: 'email'

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -37,7 +37,9 @@ If you use the administration UI in YunoHost to setup a mail forwarding address 
 
 For example, your user has email address `foo@myyunohostdomain.org` and all mail is forwarded to `foo@theirexternalmail.com`. Discourse receives replies from `foo@theirexternalmail.com` but cannot understand how to deliver this to the user account with `foo@myyunohostdomain.org` configured.
 
-Their is on-going work to allow for [multiple email addresses for one user](https://meta.discourse.org/t/additional-email-address-per-user-account-support/59847) in Discourse development but at current major version (2.3 as of 2019-08-06), there is no web interface for this functionality. It is possible to set it up via the command-line interface but it is **experimental** and you should not undertake this work unless you take some time to understand what it is you are going to do.
+To fix this you can manually add secondary email address on the user profile. We have also created a patch to allow you to define the first forward mail address if exists as primary. To activate this, go in `Discourse > Plugins > LDAP` and change `ldap_email` settings value to `maildrop` instead of `email`
+
+Another solution could be to use yunohost user hooks to create secondary emails automatically.
 
 Here's how to setup a secondary mail address for a user account:
 

--- a/patches/ldap-auth/1-mail-attribute.patch
+++ b/patches/ldap-auth/1-mail-attribute.patch
@@ -1,0 +1,59 @@
+diff --git a/config/locales/server.en.yml b/config/locales/server.en.yml
+index 172214a..de4c3e9 100644
+--- a/config/locales/server.en.yml
++++ b/config/locales/server.en.yml
+@@ -11,3 +11,4 @@ en:
+     ldap_bind_dn: "LDAP bind dn (needed if LDAP server does not allow anonymous binding)"
+     ldap_password:  "LDAP bind password (needed if LDAP server does not allow anonymous binding)"
+     ldap_filter:  "LDAP filter (for group based authentication)"
++    ldap_email:  "Mail attribute to bind in priority to discourse primary mail"
+diff --git a/config/settings.yml b/config/settings.yml
+index 157fe53..e3582a1 100644
+--- a/config/settings.yml
++++ b/config/settings.yml
+@@ -24,3 +24,5 @@ plugins:
+     secret: true
+   ldap_filter:
+     default: ''
++  ldap_email:
++    default: 'email'
+diff --git a/lib/ldap_user.rb b/lib/ldap_user.rb
+index 92391e9..0327656 100644
+--- a/lib/ldap_user.rb
++++ b/lib/ldap_user.rb
+@@ -7,6 +7,14 @@ class LDAPUser
+     @email = auth_info[:email]
+     @username = auth_info[:nickname]
+     @user = SiteSetting.ldap_lookup_users_by == 'username' ? User.find_by_username(@username) : User.find_by_email(@email)
++    primary_email = @user.user_emails.find_by(email: @user.email)
++    if primary_email.present?
++      primary_email.update!(email: @email)
++    else
++      @user.user_emails.update_all(primary: false)
++      @user.user_emails.create!(email: @email, primary: true)
++    end
++    @user.reload
+     create_user_groups(auth_info[:groups]) unless self.account_exists?
+   end
+ 
+diff --git a/plugin.rb b/plugin.rb
+index 5e129da..a56fd85 100644
+--- a/plugin.rb
++++ b/plugin.rb
+@@ -26,6 +26,16 @@ class ::LDAPAuthenticator < ::Auth::Authenticator
+   end
+ 
+   def after_authenticate(auth_options)
++    if SiteSetting.ldap_email != 'email'
++      if not auth_options.extra[:raw_info][SiteSetting.ldap_email].blank?
++        emails = Array(auth_options.extra[:raw_info][SiteSetting.ldap_email])
++          .select { |email| email.match?(/\A[^@\s]+@[^@\s]+\z/) }
++        if not emails.empty?
++          auth_options.info[:email] = emails.first()
++        end
++      end
++    end
++
+     auth_result(auth_options.info)
+   end
+ 


### PR DESCRIPTION
## Problem

See https://github.com/jonmbake/discourse-ldap-auth/pull/94

## Solution

Patch the code until the upstream plugin include this kind of features

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
