### PR TITLE
Use prebuilt ImageMagick

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -62,11 +62,14 @@ ram.runtime = "1G"
     autoupdate.upstream = "https://github.com/jonmbake/discourse-ldap-auth"
 
     [resources.sources.imagemagickv7]
-    url = "https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.1.2-29.tar.gz"
-    sha256 = "b05924ad73c6932ba62c9b32f338f0619b90b767162c8b767f3566556187a284"
-
-    autoupdate.strategy = "latest_github_tag"
-    autoupdate.upstream = "https://github.com/ImageMagick/ImageMagick"
+    amd64.url = "https://github.com/orhtej2/imagemagick-binary/releases/download/7.1.2-29/imagemagick-7.1.2-29-linux-amd64.tar.gz"
+    amd64.sha256 = "cf194bc652c5555e4c6a45e06c262db56dde3032024b4ec3d65263668d090e66"
+    arm64.url = "https://github.com/orhtej2/imagemagick-binary/releases/download/7.1.2-29/imagemagick-7.1.2-29-linux-arm64.tar.gz"
+    arm64.sha256 = "5ee02707fad2e764013603abc257aae411ea320bb72ec8b8cb4598b5ed2d924f"
+    autoupdate.strategy = "latest_github_release"
+    autoupdate.upstream = "https://github.com/orhtej2/imagemagick-binary"
+    autoupdate.asset.amd64 = "imagemagick-\\d+\\.\\d+\\.\\d+-\\d+-linux-amd64\\.tar\\.gz$"
+    autoupdate.asset.arm64 = "imagemagick-\\d+\\.\\d+\\.\\d+-\\d+-linux-arm64\\.tar\\.gz$"
 
     [resources.sources.oxipng]
     amd64.url = "https://github.com/oxipng/oxipng/releases/download/v10.1.1/oxipng-10.1.1-x86_64-unknown-linux-gnu.tar.gz"
@@ -115,17 +118,7 @@ ram.runtime = "1G"
         "pngquant",
         "redis-server",
         "zlib1g-dev",
-
-        # Dependencies of imagemagick
-        "make",
-        "libltdl-dev",
-        "libbz2-dev", "zlib1g-dev", "libfreetype6-dev", "libjpeg-dev", "liblzma-dev",
-        "libwebp-dev", "libtiff-dev", "librsvg2-dev",
-        "libpng16-16", "libpng-dev",
-        "libjpeg62-turbo", "libjpeg62-turbo-dev",
-        "libheif1", "libheif-dev",
-        "libde265-0", "libde265-dev",
-        # ${LIBWEBP}
+        "libffi-dev",
 
         "postgresql",
         "postgresql-client",

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -54,39 +54,7 @@ check_memory_requirements_upgrade() {
 tools_prefix="$install_dir/dependencies"
 
 install_imagemagick() {
-    # See https://github.com/discourse/discourse_docker/blob/main/image/base/install-imagemagick
-    ynh_setup_source --source_id="imagemagickv7" --dest_dir="$install_dir/imagemagick_source"
-    mkdir -p "$tools_prefix"
-    chown -R "$app:$app" "$install_dir/imagemagick_source" "$tools_prefix"
-
-    pushd "$install_dir/imagemagick_source"
-        ynh_exec_as_app CFLAGS="-O2 -I$tools_prefix/include -Wno-deprecated-declarations" \
-            ./configure \
-            --prefix="$tools_prefix" \
-            --enable-static \
-            --enable-bounds-checking \
-            --enable-hdri \
-            --enable-hugepages \
-            --with-threads \
-            --with-modules \
-            --with-quantum-depth=16 \
-            --without-magick-plus-plus \
-            --with-bzlib \
-            --with-zlib \
-            --without-autotrace \
-            --with-freetype \
-            --with-jpeg \
-            --without-lcms \
-            --with-lzma \
-            --with-png \
-            --with-tiff \
-            --with-heic \
-            --with-rsvg \
-            --with-webp
-        ynh_exec_as_app make all -j"$(nproc)"
-        ynh_exec_as_app LIBTOOLFLAGS=-Wnone make install
-    popd
-    ynh_safe_rm "$install_dir/imagemagick_source"
+    ynh_setup_source --source_id="imagemagickv7" --dest_dir="$tools_prefix"
 }
 
 install_oxipng() {


### PR DESCRIPTION
## Problem

- ImageMagick is built from source
- Recent Discourse sandboxing prevents it from running

## Solution

- Use self-contained prebuilts

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>