### PR TITLE
Fix primary admin LDAP login

### DIFF
--- a/conf/settings.yml
+++ b/conf/settings.yml
@@ -4,7 +4,7 @@ plugins:
   ldap_user_create_mode:
     default: 'auto'
   ldap_lookup_users_by:
-    default: 'username'
+    default: 'email'
   ldap_hostname:
     default: 'localhost'
   ldap_port:


### PR DESCRIPTION
## Problem

- Primary admin (the one selected at install time) unable to log in via LDAP
- This is because for some reason `admin:create` does not take user name and guesses `user1` as an appropriate name for `whatever@domain.tld` 🤷 

## Solution

- Authenticate via e-mail, these take into account both primary and secondary addresses

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>